### PR TITLE
Add tours and tourist tours

### DIFF
--- a/app/assets/stylesheets/tours.scss
+++ b/app/assets/stylesheets/tours.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the tours controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,3 +1,11 @@
 class HomeController < ApplicationController
+  before_action :authenticate_user!
+  before_action :redirect
   def index; end
+
+  private
+
+  def redirect
+    redirect_to tours_path, notice: 'Succesfully Signed-in!' if agency_signed_in?
+  end
 end

--- a/app/controllers/tours_controller.rb
+++ b/app/controllers/tours_controller.rb
@@ -1,0 +1,45 @@
+class ToursController < ApplicationController
+  before_action :authenticate_agency!, except: %i[index show]
+
+  def index
+    if tourist_signed_in?
+      @tours = Tour.all
+    elsif agency_signed_in?
+      @tours = current_agency.tours.all
+    end
+  end
+
+  def show
+    @tour = Tour.find(params[:id])
+  end
+
+  def new
+    @tour = current_agency.tours.build
+  end
+
+  def create
+    @tour = current_agency.tours.build(tour_params)
+    if @tour.valid?
+      @tour.save
+      redirect_to tours_path, notice: "Successfully created #{@tour.name} package"
+    else
+      redirect_back fallback_location: new_tour_path, alert: @tour.errors.full_messages.first
+    end
+  end
+
+  def update
+    @tour = Tour.find(params[:id])
+    if @tour.update(tour_params)
+      flash[:notice] = 'tour was updated successfully.'
+      redirect_to tour_path(@tour)
+    else
+      render 'edit'
+    end
+  end
+
+  private
+
+  def tour_params
+    params.require(:tour).permit(:name, :price, :location, :duration, :details, images: [])
+  end
+end

--- a/app/controllers/tours_controller.rb
+++ b/app/controllers/tours_controller.rb
@@ -27,6 +27,10 @@ class ToursController < ApplicationController
     end
   end
 
+  def edit
+    @tour = Tour.find(params[:id])
+  end
+
   def update
     @tour = Tour.find(params[:id])
     if @tour.update(tour_params)

--- a/app/helpers/tours_helper.rb
+++ b/app/helpers/tours_helper.rb
@@ -1,0 +1,2 @@
+module ToursHelper
+end

--- a/app/javascript/packs/image_preview.js
+++ b/app/javascript/packs/image_preview.js
@@ -1,0 +1,34 @@
+$(function () {
+    const output = document.getElementById('img_prev');
+    // Multiple images preview in browser
+    var imagesPreview = function(input, placeToInsertImagePreview) {
+        $(placeToInsertImagePreview).empty()
+        if (input.files) {
+            var filesAmount = input.files.length;
+
+            for (i = 0; i < filesAmount; i++) {
+                var reader = new FileReader();
+
+                reader.onload = function(event) {
+                    $($.parseHTML('<img>')).attr('src', event.target.result).addClass('tour_img').appendTo(placeToInsertImagePreview);
+                }
+
+                reader.readAsDataURL(input.files[i]);
+            }
+        }
+
+    };
+
+    $('#tour_images').on('change', function() {
+        imagesPreview(this, 'div.images-container');
+    });
+    $('#images-prev').on("click", function (event) {
+        $('img.active').removeClass('active')
+        $(event.target).closest("img").toggleClass("active");
+        console.log(output);
+        output.src = $(event.target).closest("img").attr('src')
+    });
+
+
+
+});

--- a/app/views/tours/edit.html.erb
+++ b/app/views/tours/edit.html.erb
@@ -4,7 +4,7 @@
       <h1 class="heading-primary-h1">Create a new Tour</h1>
       <%= render 'shared/errors', obj: @tour %>
       <div class="form-style">
-        <%= form_with scope: :tour, url: tours_path, local:true do |f|%>
+        <%= form_with scope: :tour, model: @tour,method: :patch, local:true do |f|%>
           <div class="form-group pb-3">    
             <%= f.text_field :name, autofocus: true,placeholder:"Package Name",class:"form-control" %>
           </div>
@@ -32,7 +32,7 @@
             </div>
             <div class="d-flex flex-row-reverse">
               <%= link_to 'Cancel',tours_path, class:'btn btn-danger' %> 
-              <%= f.submit "Post",class:"btn btn-success mx-3" %>
+              <%= f.submit "Update",class:"btn btn-success mx-3" %>
             </div>
         <% end %>
       </div>

--- a/app/views/tours/index.html.erb
+++ b/app/views/tours/index.html.erb
@@ -1,0 +1,34 @@
+<% if @tours.count == 0 %>
+
+<div class="d-flex justify-content-center" id="cont">
+    <%= image_tag("journey-animate.svg")%>
+    <img src="journey-animate.svg" height="200" alt="" />
+</div>
+
+<div class="d-flex justify-content-center">
+<%= link_to 'Create Tour', new_tour_path, class:"h1 text-secondary"%>
+</div>
+
+<%else%>
+<br/><br/>
+<div class="d-flex justify-content-center flex-wrap">
+<% @tours.each do |tour|%>
+  <div class="card m-3" style="width: 20rem;">
+    <% if tour.images.attached?%>
+            <img class="card-img-top" src="<%=(url_for(tour.images.first))%>" alt="...">
+    <%end%>
+    <div class="card-body">
+        <h4 class="card-title">Name: <%= tour.name%></h4>
+        <h6 class="card-text">Price: <%= tour.price%></h6>
+        <h6 class="card-text">Location: <%= tour.location%></h6>
+        <%if tourist_signed_in?%>
+            <%= link_to 'Show Package', tour_path(tour.id),class:"btn btn-primary"%>
+        <%else%>
+            <%= link_to 'Show', tour_path(tour),class:"btn btn-primary"%>
+        <%end%>
+    </div>
+   </div>
+<%end%>
+</div>
+
+<%end%>

--- a/app/views/tours/new.html.erb
+++ b/app/views/tours/new.html.erb
@@ -1,0 +1,42 @@
+<div class="container">
+  <div class="row m-5 no-gutters shadow-lg">
+    <div class="col bg-white p-5">
+      <h1 class="heading-primary-h1">Create a new Tour</h1>
+      <%= render 'shared/errors', obj: @tour %>
+      <div class="form-style">
+        <%= form_with scope: :tour, url: tours_path, local:true do |f|%>
+          <div class="form-group pb-3">    
+            <%= f.text_field :name, autofocus: true,placeholder:"Package Name",class:"form-control" %>
+          </div>
+          <div class="form-group pb-3">   
+            <%= f.number_field :price,placeholder:"Price",class:"form-control" %>
+          </div>
+          <div class="form-group pb-3">   
+            <%= f.text_field :location, placeholder: "Tour location" ,class:"form-control" %>
+          </div>
+          <div class="form-group pb-3">   
+            <%= f.number_field :duration, step:1, placeholder: "Duration" ,class:"form-control" %>
+          </div>
+          <div class="col bg-white p-5">
+              <img class="img-fluid" id="img_prev" src="<%= asset_path('upload_image.png')%>" alt="">
+              <div class="images-container p-3" id='images-prev'> 
+              </div>
+              <div class="mb-3">
+                <%= f.label :"Select Hero Image",:class=>"form-label"%>
+                <%= f.file_field :images, multiple: true,:class=>"form-control form-control-lg image-upload"%>
+              </div>
+          </div>
+          <div class="mb-3">
+              <%= f.label :"Tour Details", :class=>"form-label"%><br/>
+              <%= f.rich_text_area :details, wrap: "hard", placeholder: "Tour Details here" ,:class=>"form-control blog-body"%>
+            </div>
+            <div class="d-flex flex-row-reverse">
+              <%= link_to 'Cancel',tours_path, class:'btn btn-danger' %> 
+              <%= f.submit "Post",class:"btn btn-success mx-3" %>
+            </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>
+<%= javascript_pack_tag 'image_preview' %>

--- a/app/views/tours/show.html.erb
+++ b/app/views/tours/show.html.erb
@@ -1,0 +1,48 @@
+<br/>
+<div class="card text-left">
+    <div class="card-header d-flex justify-content-between"><h1><%=@tour.name%></h1>
+    <%= link_to 'Edit', edit_tour_path, class:"nav-link"%>
+    </div>
+    <div id="carouselExampleIndicators" class="carousel slide" data-bs-ride="carousel">
+    <div class="carousel-indicators">
+        <button type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>
+        <button type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide-to="1" aria-label="Slide 2"></button>
+        <button type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide-to="2" aria-label="Slide 3"></button>
+    </div>
+    <div class="carousel-inner">
+    <% if @tour.images.attached?%>
+            <%@tour.images.each do |image|%>
+        <div class="carousel-item active">
+        <img class="img-fluid d-block w-100" src="<%=(url_for(image))%>" alt="...">
+        </div>
+            <%end%>
+        <%end%>
+        <div class="carousel-item">
+        <img src="https://images.unsplash.com/photo-1508672019048-805c876b67e2?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=793&q=80" class="d-block w-100" alt="...">
+        </div>
+        <div class="carousel-item">
+        <img src="https://images.unsplash.com/photo-1530789253388-582c481c54b0?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=750&q=80" class="d-block w-100" alt="...">
+        </div>
+    </div>
+    <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide="prev">
+        <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+        <span class="visually-hidden">Previous</span>
+    </button>
+    <button class="carousel-control-next" type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide="next">
+        <span class="carousel-control-next-icon" aria-hidden="true"></span>
+        <span class="visually-hidden">Next</span>
+    </button>
+    </div>
+    <div class="card-body">
+    <h2>Location: <%=@tour.location%></h2>
+    <h3>Price: <%=@tour.price%> </h3>
+    <h3>Duration: <%=@tour.duration%></h3>
+    <h3>Details:</h3>
+    <p><%=@tour.details%></p>
+    </div>
+    <%if user_signed_in? && current_user&.type != 'Agency' %>
+    <%=link_to chat_user_path(user_id: "#{@tour.agency.id}"), method: :post  ,class: 'btn btn-primary' do%>
+        <i class="fab fa-facebook-messenger"></i>Message Me
+      <%end%> 
+    <%end%>
+</div>

--- a/spec/requests/tours_controllers_spec.rb
+++ b/spec/requests/tours_controllers_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe 'ToursControllers', type: :request do
       get new_tour_path
       expect(response).to have_http_status(:ok)
     end
+
+    it 'gets the edit tour template' do
+      get edit_tour_path(tour)
+      expect(response).to have_http_status(:ok)
+    end
   end
 
   context 'when POST and PATCH tours' do

--- a/spec/requests/tours_controllers_spec.rb
+++ b/spec/requests/tours_controllers_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe 'ToursControllers', type: :request do
+  let!(:agency) { create(:approved_agency) }
+  let!(:tour) { create(:tour, agency: agency) }
+
+  before { sign_in(agency) }
+
+  context 'when GET in tours' do
+    it 'gets all active tours' do
+      get tours_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'gets the specifc tour' do
+      get tour_path(tour)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'gets the new tour template' do
+      get new_tour_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context 'when POST and PATCH tours' do
+    it 'posts a new tour' do
+      post tours_path, params: { tour: { name: 'Boracay', location: 'Boracay', duration: 3, price: 300, agency: agency } }
+      expect(response).to redirect_to(tours_path)
+    end
+
+    it 'updates a tour' do
+      patch tour_path(tour), params: { tour: { name: 'Boracay', location: 'Boracay', duration: 3, price: 300, agency: agency } }
+      expect(response).to redirect_to(tour_path)
+    end
+  end
+end


### PR DESCRIPTION
This PR is mainly for generating the tours controllers and views, by applying the TDD principle. In the index controller, when the agency is signed in, it shows all the tours of the current_agency while it shows all the tours regardless of which agency when a tourist is signed in. On the show page, if the agency is signed in and the shown tour belongs to the agency it shows a button that redirects to the edit page which allows the agency to edit his/her tour.

### Tour Index
![tours_index](https://user-images.githubusercontent.com/76772310/126042657-d42dc93c-b856-4239-8393-19042e1b9a7b.png)
### Tour show page
![tour_edit_page](https://user-images.githubusercontent.com/76772310/126042663-4e004144-72b6-45f2-9bd1-70e673c90564.png)
### Tour edit page
![tour_patch_page](https://user-images.githubusercontent.com/76772310/126042667-aaf17d22-3049-4b99-a61c-b5d05ba7ae74.png)
### New tour page
![tour_new_page](https://user-images.githubusercontent.com/76772310/126042692-ecdc570e-54c8-4e5d-a68d-d95f13969ad6.png)
